### PR TITLE
fix: ignore 1password, dashlane and lastpass popups

### DIFF
--- a/src/VueTailwindDatePicker.vue
+++ b/src/VueTailwindDatePicker.vue
@@ -1221,6 +1221,9 @@ provide('setToCustomShortcut', setToCustomShortcut)
             inputClasses ||
             'pl-3 pr-12 py-2.5 rounded-lg overflow-hidden border-solid text-sm text-vtd-secondary-700 placeholder-vtd-secondary-400 transition-colors bg-white border border-vtd-secondary-300 focus:border-vtd-primary-300 focus:ring focus:ring-vtd-primary-500 focus:ring-opacity-10 focus:outline-none dark:bg-vtd-secondary-800 dark:border-vtd-secondary-700 dark:text-vtd-secondary-100 dark:placeholder-vtd-secondary-500 dark:focus:border-vtd-primary-500 dark:focus:ring-opacity-20'
           "
+          autocomplete="off"
+          data-lpignore="true"
+          data-form-type="other"
           v-bind="$attrs"
           v-model="pickerValue"
           :placeholder="givenPlaceholder"


### PR DESCRIPTION
Fixes #2 

These attributes will make this component ignore dashlane, 1password and LastPass.

Should be noted that the [1password icon will still be there](https://1password.community/discussion/comment/612323/#Comment_612323), but the popup will not be displayed.
