### PR TITLE
w-full for single date picker

### DIFF
--- a/src/VueTailwindDatePicker.vue
+++ b/src/VueTailwindDatePicker.vue
@@ -1313,7 +1313,7 @@ provide('setToCustomShortcut', setToCustomShortcut)
                   :i18n="props.options.shortcuts"
                   :close="close"
                 />
-                <div class="relative flex flex-wrap sm:flex-nowrap p-1">
+                <div class="relative flex flex-wrap sm:flex-nowrap p-1 w-full">
                   <div
                     v-if="asRange() && !props.asSingle"
                     class="hidden h-full absolute inset-0 sm:flex justify-center items-center"
@@ -1424,7 +1424,7 @@ provide('setToCustomShortcut', setToCustomShortcut)
           :as-single="props.asSingle"
           :i18n="props.options.shortcuts"
         />
-        <div class="relative flex flex-wrap sm:flex-nowrap p-1">
+        <div class="relative flex flex-wrap sm:flex-nowrap p-1 w-full">
           <div
             v-if="asRange() && !props.asSingle"
             class="hidden h-full absolute inset-0 sm:flex justify-center items-center"


### PR DESCRIPTION
On small screens, a single date picker looks bad (not centered):

<img width="505" alt="Screen Shot 2022-12-22 at 13 03 23" src="https://user-images.githubusercontent.com/28765966/209118711-67816ea7-99df-47c0-8f2e-60d22ecb93ef.png">

But I am not sure about Popover width...