### PR TITLE
Set initial value when mounting component (fixes #7)

### DIFF
--- a/src/VueTailwindDatePicker.vue
+++ b/src/VueTailwindDatePicker.vue
@@ -588,6 +588,11 @@ const setDate = (date, asNext, close) => {
   }
 }
 
+onBeforeMount(() => {
+  setDate(dayjs(props.modelValue[0]), false)
+  setDate(dayjs(props.modelValue[1]), false)
+})
+
 const applyDate = (close) => {
   if (applyValue.value.length < 1) return false
   let date


### PR DESCRIPTION
Well, this is a really fast and dirty solution to the problem which also assumes that the value is always an array and always a date range. You may change this to address the other possible configurations, but it's at least working fine for me.