### PR TITLE
Added prop for choose between weekdaysShort and weekdaysMin

### DIFF
--- a/docs/props.md
+++ b/docs/props.md
@@ -18,6 +18,7 @@
   const dateValue13 = ref([])
   const dateValue14 = ref([])
   const dateValue15 = ref([])
+  const dateValue16 = ref([])
   const formatter = ref({
     date: 'DD MMM YYYY',
     month: 'MMM'
@@ -297,6 +298,28 @@ const startFrom = new Date(2020, 0, 1)
 
 <template>
     <vue-tailwind-datepicker :start-from="startFrom" v-model="dateValue" />
+</template>
+```
+
+## Weekdays size
+
+If you need to use a minimum number of characters for the name of the days of the week (Sun -> Su, Mon -> Mo, etc.), use `min`, by default `weekdaysSize` is `short` (Sun, Mon, etc.).
+
+<DemoLayout>
+  <VueTailwindDatePicker
+    weekdays-size="min"
+    v-model="dateValue16"
+  />
+</DemoLayout>
+
+```vue
+<script setup>
+import { ref } from 'vue'
+const dateValue = ref([])
+</script>
+
+<template>
+    <vue-tailwind-datepicker weekdays-size="min" v-model="dateValue" />
 </template>
 ```
 

--- a/src/VueTailwindDatePicker.vue
+++ b/src/VueTailwindDatePicker.vue
@@ -88,6 +88,10 @@ const props = defineProps({
     type: [Object, String],
     default: () => new Date()
   },
+  weekdaysSize: {
+    type: String,
+    default: 'short'
+  },
   options: {
     type: Object,
     default: () => ({
@@ -145,7 +149,7 @@ const datepicker = ref({
     previous: dayjs().year(),
     next: dayjs().year()
   },
-  weeks: dayjs.weekdaysShort(),
+  weeks: props.weekdaysSize === 'min' ? dayjs.weekdaysMin() : dayjs.weekdaysShort(),
   months: props.formatter.month === 'MMM' ? dayjs.monthsShort() : dayjs.months()
 })
 const weeks = computed(() => datepicker.value.weeks)
@@ -1222,7 +1226,9 @@ watchEffect(() => {
               datepicker.value.year.next = datepicker.value.next.year()
             }
           }
-          datepicker.value.weeks = isFirstMonday() ? shuffleWeekdays(dayjs.weekdaysShort()) : dayjs.weekdaysShort()
+
+          const days = props.weekdaysSize === 'min' ? dayjs.weekdaysMin() : dayjs.weekdaysShort()
+          datepicker.value.weeks = isFirstMonday() ? shuffleWeekdays(days) : days
           datepicker.value.months = props.formatter.month === 'MMM' ? dayjs.monthsShort() : dayjs.months()
         })
         .catch((e) => {


### PR DESCRIPTION
Issue: https://github.com/elreco/vue-tailwind-datepicker/issues/67

Now you can choose between `short` and `min` names of the days of the week: 

<img width="376" alt="image" src="https://user-images.githubusercontent.com/28765966/219634040-b741ec7e-c218-4df9-aa01-546f53aedecb.png">
