### PR TITLE
fix(input): stop event propagation on input typing

### DIFF
--- a/src/VueTailwindDatePicker.vue
+++ b/src/VueTailwindDatePicker.vue
@@ -1438,7 +1438,7 @@ provide(setToCustomShortcutKey, setToCustomShortcut)
             inputClasses
               || 'pl-3 pr-12 py-2.5 rounded-lg overflow-hidden border-solid text-sm text-vtd-secondary-700 placeholder-vtd-secondary-400 transition-colors bg-white border border-vtd-secondary-300 focus:border-vtd-primary-300 focus:ring focus:ring-vtd-primary-500 focus:ring-opacity-10 focus:outline-none dark:bg-vtd-secondary-800 dark:border-vtd-secondary-700 dark:text-vtd-secondary-100 dark:placeholder-vtd-secondary-500 dark:focus:border-vtd-primary-500 dark:focus:ring-opacity-20',
           ]" autocomplete="off" data-lpignore="true" data-form-type="other" :placeholder="givenPlaceholder"
-          @keyup="keyUp"
+          @keyup.stop="keyUp" @keydown.stop
         >
         <div class="absolute inset-y-0 right-0 inline-flex items-center rounded-md overflow-hidden">
           <button


### PR DESCRIPTION
block event propagation to avoid calendar opening due to key mapping (enter / space) on headless popover

fix #110