### PR TITLE
fix: export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "exports": {
     ".": {
       "import": "./dist/vue-tailwind-datepicker.js",
-      "require": "./dist/vue-tailwind-datepicker.umd.cjs"
+      "require": "./dist/vue-tailwind-datepicker.umd.cjs",
+      "types": "./dist/types.d.ts"
     }
   },
   "main": "./dist/vue-tailwind-datepicker.umd.cjs",


### PR DESCRIPTION
Type checking failed earlier in nuxt with yarn nuxi typecheck.
Now that the types are exported, the issue is fixed.