### PR TITLE
Fix ignored disableDate function when date has been set

### DIFF
--- a/src/VueTailwindDatePicker.vue
+++ b/src/VueTailwindDatePicker.vue
@@ -466,7 +466,7 @@ function asRange() {
 }
 
 function inRangeDate(date: Dayjs) {
-  if (props.disableInRange)
+  if (props.disableInRange || typeof props.disableDate === 'function')
     return false
   if (pickerValue.value === '')
     return false


### PR DESCRIPTION
Fixes the need for ```disable-in-range ``` when passes a disableDate function to workaround #154 
https://stackblitz.com/edit/vue-tailwind-datepicker-jusekn?file=src%2Fcomponents%2FPlayground.vue