### PR TITLE
fix: stop self-injecting bundled Tailwind CSS into document.head

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ npm install vue-tailwind-datepicker
 yarn add vue-tailwind-datepicker
 ```
 
+### Import CSS
+
+⚠️ Styles are no longer auto-injected. You **must** import the stylesheet yourself:
+
+```js
+import "vue-tailwind-datepicker/style.css";
+```
+
 ## Simple Usage
 
 How it works,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,17 @@ $ npm install vue-tailwind-datepicker
 $ yarn add vue-tailwind-datepicker
 ```
 
+## Import CSS
+
+::: warning
+⚠️ Since v3, styles are no longer auto-injected. You **must** import the stylesheet yourself.
+:::
+
+```js
+// main.js
+import "vue-tailwind-datepicker/style.css";
+```
+
 ## How it works
 
 Setup the component globally

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
       "name": "vue-tailwind-datepicker",
       "version": "1.7.4",
       "dependencies": {
-        "@vueuse/core": "^10.5.0",
-        "vite-plugin-css-injected-by-js": "^3.3.1"
+        "@vueuse/core": "^10.5.0"
       },
       "devDependencies": {
         "@antfu/eslint-config": "^0.43.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
       "types": "./dist/types.d.ts",
       "import": "./dist/vue-tailwind-datepicker.js",
       "require": "./dist/vue-tailwind-datepicker.umd.cjs"
-    }
+    },
+    "./style.css": "./dist/vue-tailwind-datepicker.css"
   },
   "main": "./dist/vue-tailwind-datepicker.umd.cjs",
   "module": "./dist/vue-tailwind-datepicker.js",
@@ -171,8 +172,7 @@
     "vue": "^3.3.13"
   },
   "dependencies": {
-    "@vueuse/core": "^10.5.0",
-    "vite-plugin-css-injected-by-js": "^3.3.1"
+    "@vueuse/core": "^10.5.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.43.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
-import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 import dts from "vite-plugin-dts";
 
 // https://vitejs.dev/config/
@@ -23,5 +22,5 @@ export default defineConfig({
       },
     },
   },
-  plugins: [vue(), cssInjectedByJsPlugin(), dts({ rollupTypes: true })],
+  plugins: [vue(), dts({ rollupTypes: true })],
 })


### PR DESCRIPTION
## Problem

`vite-plugin-css-injected-by-js` bundles this package's compiled Tailwind CSS (Preflight + utilities) into the JS output and unconditionally injects it into `document.head` on import

This collides with any consumer that also uses Tailwind and defines its own `@layer base` (headings, dark-mode variant, form resets, etc.). Tailwind wraps everything in native CSS `@layer`, so two independent Tailwind builds merge into one cascade layer in DOM order
Whichever stylesheet loads last wins per-property, regardless of specificity
Since this package injects its stylesheet at import time, it frequently lands *after* the consumer's own styles and silently overrides unrelated parts of their page (we hit this with heading styles disappearing app-wide after importing the datepicker)

## Fix

- Remove `vite-plugin-css-injected-by-js`. The CSS import in `src/main.ts`  now emits as a normal build asset (`dist/vue-tailwind-datepicker.css`)   instead of being force-injected
- Add an explicit `"./style.css"` entry to `exports` so consumers who want the packaged styles can opt in (`import "vue-tailwind-datepicker/style.css"`), without imposing it on everyone

## Compatibility

- **Tailwind users** : no change needed
Tailwind content-scanning already regenerates the same utility classes from this package's source, independent of the bundled CSS
- **Non-Tailwind users** relying on the previous auto-injected styles: add one import
`import "vue-tailwind-datepicker/style.css"`
Called out as a breaking change for the next major version